### PR TITLE
Fix get attributes for inherited attributes

### DIFF
--- a/src/ImmediateReflection.Tests/Extensions/ImmediateAttributesExtensionsTests.cs
+++ b/src/ImmediateReflection.Tests/Extensions/ImmediateAttributesExtensionsTests.cs
@@ -134,6 +134,27 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true);
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    typeof(TestClassOnlyInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    typeof(TestClassOnlyInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    typeof(TestClassInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    typeof(TestClassInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    true);
+
                 #endregion
 
                 #region ImmediateField
@@ -200,6 +221,27 @@ namespace ImmediateReflection.Tests
                 yield return new TestCaseData(
                     TestFieldMultiAttributesFieldInfo,
                     typeof(SecondTestClassAttribute),
+                    true);
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    TestFieldOnlyInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestFieldOnlyInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    TestFieldInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestFieldInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
                     true);
 
                 #endregion
@@ -303,6 +345,27 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true);
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    TestPropertyOnlyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestPropertyOnlyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    TestPropertyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestPropertyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
                 #endregion
             }
         }
@@ -321,107 +384,140 @@ namespace ImmediateReflection.Tests
             #region ImmediateType
 
             // No attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassNoAttribute), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassNoAttribute), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassNoAttribute));
 
             // With attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttribute), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttribute), true);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttributes), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttributes), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttribute));
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassWithAttributes));
 
             // Without requested attribute
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassWithAttribute), false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassWithAttribute), true);
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassWithAttribute));
 
             // Attribute not inherited
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassNoAttribute), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassNoAttribute), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassNoAttribute));
 
             // Attribute inherited 1
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1));
 
             // Attribute inherited 2
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2));
 
             // Several attributes
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassMultiAttributes), false);
-            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassMultiAttributes), true);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassMultiAttributes), false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassMultiAttributes), true);
+            CheckHasAndGetAttribute<TestClassAttribute>(typeof(TestClassMultiAttributes));
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(typeof(TestClassMultiAttributes));
 
             #endregion
 
             #region ImmediateField
 
             // No attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldNoAttributeFieldInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldNoAttributeFieldInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldNoAttributeFieldInfo);
 
             // With attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributeFieldInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributeFieldInfo, true);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributesFieldInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributesFieldInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributeFieldInfo);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldAttributesFieldInfo);
 
             // Without requested attribute
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldAttributeFieldInfo, false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldAttributeFieldInfo, true);
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldAttributeFieldInfo);
 
             // Several attributes
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldMultiAttributesFieldInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldMultiAttributesFieldInfo, true);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo, false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestFieldMultiAttributesFieldInfo);
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo);
 
             #endregion
 
             #region ImmediateProperty
 
             // No attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyNoAttributePropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyNoAttributePropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyNoAttributePropertyInfo);
 
             // With attribute
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributePropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributePropertyInfo, true);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributesPropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributesPropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributePropertyInfo);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyAttributesPropertyInfo);
 
             // Without requested attribute
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo, false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo, true);
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo);
 
             // Attribute not inherited
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo);
 
             // Attribute inherited 1
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo);
 
             // Attribute inherited 2
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo);
 
             // Several attributes
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, false);
-            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, true);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, false);
-            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, true);
+            CheckHasAndGetAttribute<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo);
+            CheckHasAndGetAttribute<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo);
 
             #endregion
 
             #region Local function
 
-            void CheckHasAndGetAttribute<TAttribute>(MemberInfo member, bool inherit)
+            void CheckHasAndGetAttribute<TAttribute>(MemberInfo member)
                 where TAttribute : Attribute
             {
-                ImmediateMember immediateMember = GetImmediateMember(member);
-                Assert.AreEqual(immediateMember.IsDefined<TAttribute>(inherit), ImmediateAttributesExtensions.IsDefinedImmediateAttribute<TAttribute>(member, inherit));
-                Assert.AreEqual(immediateMember.GetAttribute<TAttribute>(inherit), ImmediateAttributesExtensions.GetImmediateAttribute<TAttribute>(member, inherit));
+                CheckHasAndGetAttributeHelper(false);
+                CheckHasAndGetAttributeHelper(true);
+
+                #region Local function
+
+                void CheckHasAndGetAttributeHelper(bool inherit)
+                {
+                    ImmediateMember immediateMember = GetImmediateMember(member);
+                    Assert.AreEqual(immediateMember.IsDefined<TAttribute>(inherit), ImmediateAttributesExtensions.IsDefinedImmediateAttribute<TAttribute>(member, inherit));
+                    Assert.AreEqual(immediateMember.GetAttribute<TAttribute>(inherit), ImmediateAttributesExtensions.GetImmediateAttribute<TAttribute>(member, inherit));
+                }
+
+                #endregion
+            }
+
+            #endregion
+        }
+
+        [Test]
+        public void TemplateIsDefinedAndGetAttribute_Inherited()
+        {
+            #region ImmediateType
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(typeof(TestClassOnlyInheritedAttribute));
+            CheckHasAndGetAttribute<TestBaseAttribute>(typeof(TestClassInheritedAttribute));
+
+            #endregion
+
+            #region ImmediateField
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(TestFieldOnlyInheritingAttributeFieldInfo);
+            CheckHasAndGetAttribute<TestBaseAttribute>(TestFieldInheritingAttributeFieldInfo);
+
+            #endregion
+
+            #region ImmediateProperty
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(TestPropertyOnlyInheritingAttributePropertyInfo);
+            CheckHasAndGetAttribute<TestBaseAttribute>(TestPropertyInheritingAttributePropertyInfo);
+
+            #endregion
+
+            #region Local function
+
+            void CheckHasAndGetAttribute<TAttribute>(MemberInfo member)
+                where TAttribute : Attribute
+            {
+                CheckHasAndGetAttributeHelper(false);
+                CheckHasAndGetAttributeHelper(true);
+
+                #region Local function
+
+                void CheckHasAndGetAttributeHelper(bool inherit)
+                {
+                    ImmediateMember immediateMember = GetImmediateMember(member);
+                    Assert.AreEqual(immediateMember.IsDefined<TAttribute>(inherit), ImmediateAttributesExtensions.IsDefinedImmediateAttribute<TAttribute>(member, inherit));
+                    Assert.AreEqual(immediateMember.GetAttribute<TAttribute>(inherit), ImmediateAttributesExtensions.GetImmediateAttribute<TAttribute>(member, inherit));
+                }
+
+                #endregion
             }
 
             #endregion
@@ -687,6 +783,27 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true);
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    typeof(TestClassOnlyInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    typeof(TestClassOnlyInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    typeof(TestClassInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    typeof(TestClassInheritedAttribute),
+                    typeof(TestBaseAttribute),
+                    true);
+
                 #endregion
 
                 #region ImmediateField
@@ -753,6 +870,27 @@ namespace ImmediateReflection.Tests
                 yield return new TestCaseData(
                     TestFieldMultiAttributesFieldInfo,
                     typeof(SecondTestClassAttribute),
+                    true);
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    TestFieldOnlyInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestFieldOnlyInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    TestFieldInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestFieldInheritingAttributeFieldInfo,
+                    typeof(TestBaseAttribute),
                     true);
 
                 #endregion
@@ -856,6 +994,27 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true);
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    TestPropertyOnlyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestPropertyOnlyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
+                yield return new TestCaseData(
+                    TestPropertyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    false);
+
+                yield return new TestCaseData(
+                    TestPropertyInheritingAttributePropertyInfo,
+                    typeof(TestBaseAttribute),
+                    true);
+
                 #endregion
             }
         }
@@ -877,136 +1036,142 @@ namespace ImmediateReflection.Tests
             #region ImmediateType
 
             // No attribute
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassNoAttribute), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassNoAttribute), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(TestClassNoAttribute));
 
             // With attribute
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttribute), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttribute), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttribute));
 
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttributes), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttributes), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(TestClassWithAttributes));
 
             // Without requested attribute
-            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassWithAttribute), false);
-            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassWithAttribute), true);
+            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassWithAttribute));
 
             // Attribute not inherited
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassNoAttribute), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassNoAttribute), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassNoAttribute));
 
             // Attribute inherited 1
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute1));
 
             // Attribute inherited 2
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(InheritedTestClassWithAttribute2));
 
             // Several attributes
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassMultiAttributes), false);
-            CheckGetAttributes<TestClassAttribute>(typeof(TestClassMultiAttributes), true);
-            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassMultiAttributes), false);
-            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassMultiAttributes), true);
+            CheckGetAttributes<TestClassAttribute>(typeof(TestClassMultiAttributes));
+            CheckGetAttributes<SecondTestClassAttribute>(typeof(TestClassMultiAttributes));
 
             #endregion
 
             #region ImmediateField
 
             // No attribute
-            CheckGetAttributes<TestClassAttribute>(TestFieldNoAttributeFieldInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestFieldNoAttributeFieldInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestFieldNoAttributeFieldInfo);
 
             // With attribute
-            CheckGetAttributes<TestClassAttribute>(TestFieldAttributeFieldInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestFieldAttributeFieldInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestFieldAttributeFieldInfo);
 
-            CheckGetAttributes<TestClassAttribute>(TestFieldAttributesFieldInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestFieldAttributesFieldInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestFieldAttributesFieldInfo);
 
             // Without requested attribute
-            CheckGetAttributes<SecondTestClassAttribute>(TestFieldAttributeFieldInfo, false);
-            CheckGetAttributes<SecondTestClassAttribute>(TestFieldAttributeFieldInfo, true);
+            CheckGetAttributes<SecondTestClassAttribute>(TestFieldAttributeFieldInfo);
 
             // Several attributes
-            CheckGetAttributes<TestClassAttribute>(TestFieldMultiAttributesFieldInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestFieldMultiAttributesFieldInfo, true);
-            CheckGetAttributes<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo, false);
-            CheckGetAttributes<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestFieldMultiAttributesFieldInfo);
+            CheckGetAttributes<SecondTestClassAttribute>(TestFieldMultiAttributesFieldInfo);
 
             #endregion
 
             #region ImmediateProperty
 
             // No attribute
-            CheckGetAttributes<TestClassAttribute>(TestPropertyNoAttributePropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyNoAttributePropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyNoAttributePropertyInfo);
 
             // With attribute
-            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributePropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributePropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributePropertyInfo);
 
-            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributesPropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributesPropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyAttributesPropertyInfo);
 
             // Without requested attribute
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo, false);
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo, true);
+            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyAttributePropertyInfo);
 
             // Attribute not inherited
-            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedNoAttributePropertyInfo);
 
             // Attribute inherited 1
-            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyInheritedAttribute1PropertyInfo);
 
             // Attribute inherited 2
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo, false);
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo, true);
+            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyInheritedAttribute2PropertyInfo);
 
             // Several attributes
-            CheckGetAttributes<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, false);
-            CheckGetAttributes<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, true);
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, false);
-            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo, true);
+            CheckGetAttributes<TestClassAttribute>(TestPropertyMultiAttributesPropertyInfo);
+            CheckGetAttributes<SecondTestClassAttribute>(TestPropertyMultiAttributesPropertyInfo);
 
             #endregion
 
             #region Local function
 
-            void CheckGetAttributes<TAttribute>(MemberInfo member, bool inherit)
+            void CheckGetAttributes<TAttribute>(MemberInfo member)
                 where TAttribute : Attribute
             {
-                CollectionAssert.AreEqual(
-                    GetImmediateMember(member).GetAttributes<TAttribute>(inherit),
-                    ImmediateAttributesExtensions.GetImmediateAttributes<TAttribute>(member, inherit));
+                CheckGetAttributesHelper(false);
+                CheckGetAttributesHelper(true);
+
+                void CheckGetAttributesHelper(bool inherit)
+                {
+                    CollectionAssert.AreEqual(
+                        GetImmediateMember(member).GetAttributes<TAttribute>(inherit),
+                        ImmediateAttributesExtensions.GetImmediateAttributes<TAttribute>(member, inherit));
+                }
             }
 
             #endregion
         }
 
         [Test]
-        public void GetAttributes_Inherited()
+        public void TemplateGetAttributes_Inherited()
         {
-            PropertyInfo property = typeof(TestClassInheritedAttribute).GetProperty(nameof(TestClassInheritedAttribute.TestProperty)) ?? throw new AssertionException("Cannot find property.");
-            IEnumerable<TestBaseAttribute> attributes = GetAttributes<TestBaseAttribute>(property);
+            #region ImmediateType
 
-            var imProperty = (ImmediateProperty)GetImmediateMember(property);
-            IEnumerable<TestBaseAttribute> imAttributes = imProperty.GetAttributes<TestBaseAttribute>();
+            CheckGetAttributes<TestBaseAttribute>(typeof(TestClassOnlyInheritedAttribute));
+            CheckGetAttributes<TestBaseAttribute>(typeof(TestClassInheritedAttribute));
 
-            CollectionAssert.AreEqual(attributes, imAttributes);
-            
-            IEnumerable<TAttribute> GetAttributes<TAttribute>(PropertyInfo prop)
+            #endregion
+
+            #region ImmediateField
+
+            CheckGetAttributes<TestBaseAttribute>(TestFieldOnlyInheritingAttributeFieldInfo);
+            CheckGetAttributes<TestBaseAttribute>(TestFieldInheritingAttributeFieldInfo);
+
+            #endregion
+
+            #region ImmediateProperty
+
+            CheckGetAttributes<TestBaseAttribute>(TestPropertyOnlyInheritingAttributePropertyInfo);
+            CheckGetAttributes<TestBaseAttribute>(TestPropertyInheritingAttributePropertyInfo);
+
+            #endregion
+
+            #region Local function
+
+            void CheckGetAttributes<TAttribute>(MemberInfo member)
                 where TAttribute : Attribute
-            {   
-                object[] attrs = prop.GetCustomAttributes(typeof(TAttribute), false);
-                foreach (object attr in attrs)
+            {
+                CheckGetAttributesHelper(false);
+                CheckGetAttributesHelper(true);
+
+                #region Local function
+
+                void CheckGetAttributesHelper(bool inherit)
                 {
-                    if (attr is TAttribute a)
-                        yield return a;
+                    CollectionAssert.AreEqual(
+                        GetImmediateMember(member).GetAttributes<TAttribute>(inherit),
+                        ImmediateAttributesExtensions.GetImmediateAttributes<TAttribute>(member, inherit));
                 }
+
+                #endregion
             }
+
+            #endregion
         }
 
         [TestCaseSource(nameof(CreateWrongAttributeTestCases))]

--- a/src/ImmediateReflection.Tests/Extensions/ImmediateAttributesExtensionsTests.cs
+++ b/src/ImmediateReflection.Tests/Extensions/ImmediateAttributesExtensionsTests.cs
@@ -986,6 +986,29 @@ namespace ImmediateReflection.Tests
             #endregion
         }
 
+        [Test]
+        public void GetAttributes_Inherited()
+        {
+            PropertyInfo property = typeof(TestClassInheritedAttribute).GetProperty(nameof(TestClassInheritedAttribute.TestProperty)) ?? throw new AssertionException("Cannot find property.");
+            IEnumerable<TestBaseAttribute> attributes = GetAttributes<TestBaseAttribute>(property);
+
+            var imProperty = (ImmediateProperty)GetImmediateMember(property);
+            IEnumerable<TestBaseAttribute> imAttributes = imProperty.GetAttributes<TestBaseAttribute>();
+
+            CollectionAssert.AreEqual(attributes, imAttributes);
+            
+            IEnumerable<TAttribute> GetAttributes<TAttribute>(PropertyInfo prop)
+                where TAttribute : Attribute
+            {   
+                object[] attrs = prop.GetCustomAttributes(typeof(TAttribute), false);
+                foreach (object attr in attrs)
+                {
+                    if (attr is TAttribute a)
+                        yield return a;
+                }
+            }
+        }
+
         [TestCaseSource(nameof(CreateWrongAttributeTestCases))]
         public void GetAttributes_WrongType([NotNull] MemberInfo member, [NotNull] Type attributeType, bool inherit)
         {

--- a/src/ImmediateReflection.Tests/ImmediateAttributesTestsBase.cs
+++ b/src/ImmediateReflection.Tests/ImmediateAttributesTestsBase.cs
@@ -85,6 +85,16 @@ namespace ImmediateReflection.Tests
         {
         }
 
+        protected class TestBaseAttribute : Attribute
+        {
+
+        }
+
+        protected sealed class TestInheritingAttribute : TestBaseAttribute
+        {
+
+        }
+
         #endregion
 
         #region Classes
@@ -155,6 +165,13 @@ namespace ImmediateReflection.Tests
         protected class InheritedTestClassMultiAttributes : TestClassMultiAttributes
         {
             public override int TestProperty { get; set; } = 45;
+        }
+
+        protected class TestClassInheritedAttribute
+        {
+            [TestBase]
+            [TestInheriting]
+            public int TestProperty { get; set; }
         }
 
         // ReSharper restore InconsistentNaming

--- a/src/ImmediateReflection.Tests/ImmediateAttributesTestsBase.cs
+++ b/src/ImmediateReflection.Tests/ImmediateAttributesTestsBase.cs
@@ -25,6 +25,7 @@ namespace ImmediateReflection.Tests
                 _id = id;
             }
 
+            /// <inheritdoc />
             public bool Equals(TestClassAttribute other)
             {
                 if (other is null)
@@ -34,11 +35,13 @@ namespace ImmediateReflection.Tests
                 return _id == other._id;
             }
 
+            /// <inheritdoc />
             public override bool Equals(object obj)
             {
                 return Equals(obj as TestClassAttribute);
             }
 
+            /// <inheritdoc />
             public override int GetHashCode()
             {
                 unchecked
@@ -58,6 +61,7 @@ namespace ImmediateReflection.Tests
                 _id = id;
             }
 
+            /// <inheritdoc />
             public bool Equals(SecondTestClassAttribute other)
             {
                 if (other is null)
@@ -67,11 +71,49 @@ namespace ImmediateReflection.Tests
                 return _id == other._id;
             }
 
+            /// <inheritdoc />
             public override bool Equals(object obj)
             {
                 return Equals(obj as SecondTestClassAttribute);
             }
 
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (base.GetHashCode() * 397) ^ _id;
+                }
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.All)]
+        protected sealed class ThirdTestClassAttribute : Attribute, IEquatable<ThirdTestClassAttribute>
+        {
+            private readonly int _id;
+
+            public ThirdTestClassAttribute(int id)
+            {
+                _id = id;
+            }
+
+            /// <inheritdoc />
+            public bool Equals(ThirdTestClassAttribute other)
+            {
+                if (other is null)
+                    return false;
+                if (ReferenceEquals(this, other))
+                    return true;
+                return _id == other._id;
+            }
+
+            /// <inheritdoc />
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as ThirdTestClassAttribute);
+            }
+
+            /// <inheritdoc />
             public override int GetHashCode()
             {
                 unchecked
@@ -85,14 +127,60 @@ namespace ImmediateReflection.Tests
         {
         }
 
+        [AttributeUsage(AttributeTargets.All)]
         protected class TestBaseAttribute : Attribute
         {
+            private readonly int _id;
 
+            public TestBaseAttribute(int id)
+            {
+                _id = id;
+            }
+
+            protected bool Equals(TestBaseAttribute other)
+            {
+                if (other is null)
+                    return false;
+                if (ReferenceEquals(this, other))
+                    return true;
+                return _id == other._id;
+            }
+
+            /// <inheritdoc />
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as TestBaseAttribute);
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (base.GetHashCode() * 397) ^ _id;
+                }
+            }
         }
 
+        [AttributeUsage(AttributeTargets.All)]
         protected sealed class TestInheritingAttribute : TestBaseAttribute
         {
+            public TestInheritingAttribute(int id)
+                : base(id)
+            {
+            }
 
+            /// <inheritdoc />
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as TestInheritingAttribute);
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                return base.GetHashCode() * 397;
+            }
         }
 
         #endregion
@@ -167,10 +255,29 @@ namespace ImmediateReflection.Tests
             public override int TestProperty { get; set; } = 45;
         }
 
+        [ThirdTestClass(16)]
+        [TestInheriting(17)]
+        protected class TestClassOnlyInheritedAttribute
+        {
+            [ThirdTestClass(18)]
+            [TestInheriting(19)]
+            public int _testFieldOnlyInheriting = 12;
+
+            [TestBase(20)]
+            [TestInheriting(21)]
+            public int _testField = 42;
+        }
+
+        [TestBase(22)]
+        [TestInheriting(23)]
         protected class TestClassInheritedAttribute
         {
-            [TestBase]
-            [TestInheriting]
+            [ThirdTestClass(24)]
+            [TestInheriting(25)]
+            public int TestPropertyOnlyInheriting { get; set; }
+
+            [TestBase(26)]
+            [TestInheriting(27)]
             public int TestProperty { get; set; }
         }
 
@@ -214,6 +321,14 @@ namespace ImmediateReflection.Tests
         protected static readonly PropertyInfo TestPropertyInheritedMultiAttributesPropertyInfo =
             typeof(InheritedTestClassMultiAttributes).GetProperty(nameof(InheritedTestClassMultiAttributes.TestProperty)) ?? throw new AssertionException("Cannot find property.");
 
+        [NotNull]
+        protected static readonly PropertyInfo TestPropertyOnlyInheritingAttributePropertyInfo =
+            typeof(TestClassInheritedAttribute).GetProperty(nameof(TestClassInheritedAttribute.TestPropertyOnlyInheriting)) ?? throw new AssertionException("Cannot find property.");
+
+        [NotNull]
+        protected static readonly PropertyInfo TestPropertyInheritingAttributePropertyInfo =
+            typeof(TestClassInheritedAttribute).GetProperty(nameof(TestClassInheritedAttribute.TestProperty)) ?? throw new AssertionException("Cannot find property.");
+
         // Fields //
 
         [NotNull]
@@ -231,6 +346,14 @@ namespace ImmediateReflection.Tests
         [NotNull]
         protected static readonly FieldInfo TestFieldMultiAttributesFieldInfo =
             typeof(TestClassMultiAttributes).GetField(nameof(TestClassMultiAttributes._testField)) ?? throw new AssertionException("Cannot find field.");
+
+        [NotNull]
+        protected static readonly FieldInfo TestFieldOnlyInheritingAttributeFieldInfo =
+            typeof(TestClassOnlyInheritedAttribute).GetField(nameof(TestClassOnlyInheritedAttribute._testFieldOnlyInheriting)) ?? throw new AssertionException("Cannot find field.");
+
+        [NotNull]
+        protected static readonly FieldInfo TestFieldInheritingAttributeFieldInfo =
+            typeof(TestClassOnlyInheritedAttribute).GetField(nameof(TestClassOnlyInheritedAttribute._testField)) ?? throw new AssertionException("Cannot find field.");
 
         #endregion
 

--- a/src/ImmediateReflection.Tests/ImmediateMemberTests.cs
+++ b/src/ImmediateReflection.Tests/ImmediateMemberTests.cs
@@ -133,6 +133,31 @@ namespace ImmediateReflection.Tests
                     true,
                     new SecondTestClassAttribute(1));
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestInheritingAttribute(17));
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestInheritingAttribute(17));
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestBaseAttribute(22));
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestBaseAttribute(22));
+
                 #endregion
 
                 #region ImmediateField
@@ -212,6 +237,31 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true,
                     new SecondTestClassAttribute(2));
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestInheritingAttribute(19));
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestInheritingAttribute(19));
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestBaseAttribute(20));
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestBaseAttribute(20));
 
                 #endregion
 
@@ -332,6 +382,31 @@ namespace ImmediateReflection.Tests
                     true,
                     new SecondTestClassAttribute(3));
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestInheritingAttribute(25));
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestInheritingAttribute(25));
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new TestBaseAttribute(26));
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new TestBaseAttribute(26));
+
                 #endregion
             }
         }
@@ -443,6 +518,51 @@ namespace ImmediateReflection.Tests
             CheckHasAndGetAttribute<TestClassAttribute>(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), true, new TestClassAttribute(15));
             CheckHasAndGetAttribute<SecondTestClassAttribute>(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), false, new SecondTestClassAttribute(3));
             CheckHasAndGetAttribute<SecondTestClassAttribute>(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), true, new SecondTestClassAttribute(3));
+
+            #endregion
+
+            #region Local function
+
+            void CheckHasAndGetAttribute<TAttribute>(ImmediateMember member, bool inherit, Attribute expectedAttribute)
+                where TAttribute : Attribute
+            {
+                if (expectedAttribute is null)
+                    Assert.IsFalse(member.IsDefined<TAttribute>(inherit));
+                else
+                    Assert.IsTrue(member.IsDefined<TAttribute>(inherit));
+                Assert.AreEqual(expectedAttribute, member.GetAttribute<TAttribute>(inherit));
+            }
+
+            #endregion
+        }
+
+        [Test]
+        public void TemplateIsDefinedAndGetAttribute_Inherited()
+        {
+            #region ImmediateType
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateType(typeof(TestClassOnlyInheritedAttribute)), false, new TestInheritingAttribute(17));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateType(typeof(TestClassOnlyInheritedAttribute)), true, new TestInheritingAttribute(17));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateType(typeof(TestClassInheritedAttribute)), false, new TestBaseAttribute(22));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateType(typeof(TestClassInheritedAttribute)), true, new TestBaseAttribute(22));
+
+            #endregion
+
+            #region ImmediateField
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo), false, new TestInheritingAttribute(19));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo), true, new TestInheritingAttribute(19));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateField(TestFieldInheritingAttributeFieldInfo), false, new TestBaseAttribute(20));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateField(TestFieldInheritingAttributeFieldInfo), true, new TestBaseAttribute(20));
+
+            #endregion
+
+            #region ImmediateProperty
+
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo), false, new TestInheritingAttribute(25));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo), true, new TestInheritingAttribute(25));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo), false, new TestBaseAttribute(26));
+            CheckHasAndGetAttribute<TestBaseAttribute>(new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo), true, new TestBaseAttribute(26));
 
             #endregion
 
@@ -702,6 +822,31 @@ namespace ImmediateReflection.Tests
                     true,
                     new[] { new SecondTestClassAttribute(1) });
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestInheritingAttribute(17) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestInheritingAttribute(17) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+
                 #endregion
 
                 #region ImmediateField
@@ -781,6 +926,31 @@ namespace ImmediateReflection.Tests
                     typeof(SecondTestClassAttribute),
                     true,
                     new[] { new SecondTestClassAttribute(2) });
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestInheritingAttribute(19) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestInheritingAttribute(19) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
 
                 #endregion
 
@@ -901,6 +1071,31 @@ namespace ImmediateReflection.Tests
                     true,
                     new[] { new SecondTestClassAttribute(3) });
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestInheritingAttribute(25) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestInheritingAttribute(25) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    false,
+                    new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    typeof(TestBaseAttribute),
+                    true,
+                    new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
+
                 #endregion
             }
         }
@@ -1017,6 +1212,50 @@ namespace ImmediateReflection.Tests
             CheckGetAttributes(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), true, new[] { new TestClassAttribute(15) });
             CheckGetAttributes(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), false, new[] { new SecondTestClassAttribute(3) });
             CheckGetAttributes(new ImmediateProperty(TestPropertyMultiAttributesPropertyInfo), true, new[] { new SecondTestClassAttribute(3) });
+
+            #endregion
+
+            #region Local function
+
+            void CheckGetAttributes<TAttribute>(ImmediateMember member, bool inherit, IEnumerable<TAttribute> expectedAttributes)
+                where TAttribute : Attribute
+            {
+                if (expectedAttributes is null)
+                    CollectionAssert.IsEmpty(member.GetAttributes<TAttribute>(inherit));
+                else
+                    CollectionAssert.AreEquivalent(expectedAttributes, member.GetAttributes<TAttribute>(inherit));
+            }
+
+            #endregion
+        }
+
+        [Test]
+        public void TemplateGetAttributes_Inherited()
+        {
+            #region ImmediateType
+
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateType(typeof(TestClassOnlyInheritedAttribute)), false, new[] { new TestInheritingAttribute(17) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateType(typeof(TestClassOnlyInheritedAttribute)), true, new[] { new TestInheritingAttribute(17) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateType(typeof(TestClassInheritedAttribute)), false, new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateType(typeof(TestClassInheritedAttribute)), true, new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+
+            #endregion
+
+            #region ImmediateField
+
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo), false, new[] { new TestInheritingAttribute(19) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo), true, new[] { new TestInheritingAttribute(19) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateField(TestFieldInheritingAttributeFieldInfo), false, new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateField(TestFieldInheritingAttributeFieldInfo), true, new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
+
+            #endregion
+
+            #region ImmediateProperty
+
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo), false, new[] { new TestInheritingAttribute(25) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo), true, new[] { new TestInheritingAttribute(25) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo), false, new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
+            CheckGetAttributes<TestBaseAttribute>(new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo), true, new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
 
             #endregion
 
@@ -1153,6 +1392,27 @@ namespace ImmediateReflection.Tests
                     true,
                     new Attribute[] { new TestClassAttribute(13), new SecondTestClassAttribute(1) });
 
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    false,
+                    new Attribute[] { new ThirdTestClassAttribute(16), new TestInheritingAttribute(17) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassOnlyInheritedAttribute)),
+                    true,
+                    new Attribute[] { new ThirdTestClassAttribute(16), new TestInheritingAttribute(17) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    false,
+                    new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+
+                yield return new TestCaseData(
+                    new ImmediateType(typeof(TestClassInheritedAttribute)),
+                    true,
+                    new[] { new TestBaseAttribute(22), new TestInheritingAttribute(23) });
+
                 #endregion
 
                 #region ImmediateField
@@ -1199,6 +1459,27 @@ namespace ImmediateReflection.Tests
                     new ImmediateField(TestFieldMultiAttributesFieldInfo),
                     true,
                     new Attribute[] { new TestClassAttribute(14), new SecondTestClassAttribute(2) });
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    false,
+                    new Attribute[] { new ThirdTestClassAttribute(18), new TestInheritingAttribute(19) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldOnlyInheritingAttributeFieldInfo),
+                    true,
+                    new Attribute[] { new ThirdTestClassAttribute(18), new TestInheritingAttribute(19) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    false,
+                    new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
+
+                yield return new TestCaseData(
+                    new ImmediateField(TestFieldInheritingAttributeFieldInfo),
+                    true,
+                    new[] { new TestBaseAttribute(20), new TestInheritingAttribute(21) });
 
                 #endregion
 
@@ -1289,6 +1570,27 @@ namespace ImmediateReflection.Tests
                     new ImmediateProperty(TestPropertyInheritedMultiAttributesPropertyInfo),
                     true,
                     new Attribute[] { new TestClassAttribute(15), new SecondTestClassAttribute(3) });
+
+                // Inheriting attribute
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    false,
+                    new Attribute[] { new ThirdTestClassAttribute(24), new TestInheritingAttribute(25) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyOnlyInheritingAttributePropertyInfo),
+                    true,
+                    new Attribute[] { new ThirdTestClassAttribute(24), new TestInheritingAttribute(25) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    false,
+                    new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
+
+                yield return new TestCaseData(
+                    new ImmediateProperty(TestPropertyInheritingAttributePropertyInfo),
+                    true,
+                    new[] { new TestBaseAttribute(26), new TestInheritingAttribute(27) });
 
                 #endregion
             }

--- a/src/ImmediateReflection/Cache/AttributesCache.cs
+++ b/src/ImmediateReflection/Cache/AttributesCache.cs
@@ -168,13 +168,16 @@ namespace ImmediateReflection
 
             IEnumerable<TAttribute> FindAttributes(Dictionary<Type, List<Attribute>> attributesDictionary)
             {
-                if (attributesDictionary.TryGetValue(typeof(TAttribute), out List<Attribute> attributes))
 #if SUPPORTS_SYSTEM_CORE
-                    return attributes.OfType<TAttribute>();
-                return Enumerable.Empty<TAttribute>();
+                IEnumerable<List<Attribute>> attributes = attributesDictionary
+                    .Where(kp => typeof(TAttribute).IsAssignableFrom(kp.Key))
+                    .SelectMany(kp => kp.Value); 
+                return attributes.OfType<TAttribute>();
 #else
-                    return OfType<TAttribute>(attributes);
-                return Empty<TAttribute>();
+                IEnumerable<Attribute> attributes = SelectMany(
+                    Where(attributesDictionary, kp => typeof(TAttribute).IsAssignableFrom(kp.Key)),
+                    kp => kp.Value);
+                return OfType<TAttribute>(attributes);
 #endif
             }
 

--- a/src/ImmediateReflection/Cache/AttributesCache.cs
+++ b/src/ImmediateReflection/Cache/AttributesCache.cs
@@ -169,9 +169,9 @@ namespace ImmediateReflection
             IEnumerable<TAttribute> FindAttributes(Dictionary<Type, List<Attribute>> attributesDictionary)
             {
 #if SUPPORTS_SYSTEM_CORE
-                IEnumerable<List<Attribute>> attributes = attributesDictionary
+                IEnumerable<Attribute> attributes = attributesDictionary
                     .Where(kp => typeof(TAttribute).IsAssignableFrom(kp.Key))
-                    .SelectMany(kp => kp.Value); 
+                    .SelectMany(kp => kp.Value);
                 return attributes.OfType<TAttribute>();
 #else
                 IEnumerable<Attribute> attributes = SelectMany(

--- a/src/ImmediateReflection/Compatibility/EnumerableUtils.cs
+++ b/src/ImmediateReflection/Compatibility/EnumerableUtils.cs
@@ -45,11 +45,15 @@ namespace ImmediateReflection.Utils
         /// <typeparam name="TResult">The type of the elements of the sequence returned by <paramref name="selector"/>.</typeparam>
         /// <param name="source">A sequence of values to project.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
-        /// <returns>An <see cref="IEnumerable"/> whose elements are the result of invoking the one-to-many transform
-        /// function on each element of the input sequence.</returns>
+        /// <returns>
+        /// An <see cref="IEnumerable"/> whose elements are the result of invoking the one-to-many transform
+        /// function on each element of the input sequence.
+        /// </returns>
         [Pure]
-        [NotNull]
-        public static IEnumerable<TResult> SelectMany<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
+        [NotNull, ItemNotNull]
+        public static IEnumerable<TResult> SelectMany<TSource, TResult>(
+            [NotNull, ItemNotNull] IEnumerable<TSource> source,
+            [NotNull, InstantHandle] Func<TSource, IEnumerable<TResult>> selector)
         {
             foreach (TSource item in source)
             {

--- a/src/ImmediateReflection/Compatibility/EnumerableUtils.cs
+++ b/src/ImmediateReflection/Compatibility/EnumerableUtils.cs
@@ -36,6 +36,29 @@ namespace ImmediateReflection.Utils
                 yield return selector(element);
             }
         }
+        
+        /// <summary>
+        /// Projects each element of a sequence to an <see cref="IEnumerable"/> and flattens the resulting sequences
+        /// into one sequence.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the elements of the sequence returned by <paramref name="selector"/>.</typeparam>
+        /// <param name="source">A sequence of values to project.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <returns>An <see cref="IEnumerable"/> whose elements are the result of invoking the one-to-many transform
+        /// function on each element of the input sequence.</returns>
+        [Pure]
+        [NotNull]
+        public static IEnumerable<TResult> SelectMany<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
+        {
+            foreach (TSource item in source)
+            {
+                foreach (TResult innerItem in selector(item))
+                {
+                    yield return innerItem;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets a sub set enumerable of <paramref name="source"/> elements matching the given <paramref name="predicate"/>.


### PR DESCRIPTION
Fix issue of FindAttributes that doesn't return inherited attributes of the member (+add unit test for this)